### PR TITLE
Bring the runtime info, application_id and instance_index into the payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ Sample web applications that include this package may be configured to track dep
 * Package version
 * Repository URL
 * Application Name (`application_name`)
+* Application ID (`application_id`)
 * Space ID (`space_id`)
+* Instance Index (`instance_index`)
+* Platform (`runtime`)
 * Application Version (`application_version`)
 * Application URIs (`application_uris`)
 

--- a/cf_deployment_tracker.go
+++ b/cf_deployment_tracker.go
@@ -30,6 +30,8 @@ type Event struct {
 	ApplicationVersion string   `json:"application_version"`
 	ApplicatonURIs     []string `json:"application_uris"`
 	Runtime            string   `json:"runtime"`
+	ApplicationID      string   `json:"application_id"`
+	InstanceIndex      *uint16  `json:"instance_index"`
 }
 
 func Track() (errs []error) {

--- a/cf_deployment_tracker.go
+++ b/cf_deployment_tracker.go
@@ -29,6 +29,7 @@ type Event struct {
 	SpaceID            string   `json:"space_id"`
 	ApplicationVersion string   `json:"application_version"`
 	ApplicatonURIs     []string `json:"application_uris"`
+	Runtime            string   `json:"runtime"`
 }
 
 func Track() (errs []error) {
@@ -53,6 +54,7 @@ func Track() (errs []error) {
 		return
 	}
 
+	event.Runtime = "go"
 	if info.Repository.Url != "" {
 		event.RepositoryURL = info.Repository.Url
 	}


### PR DESCRIPTION
Aimed at fixing #12 and #13, this patch adds these additional fields to the data sent to the tracker